### PR TITLE
Hack to fix message clipping in gmail

### DIFF
--- a/services/sendgrid/sendgrid.go
+++ b/services/sendgrid/sendgrid.go
@@ -57,7 +57,10 @@ func (m *Sendgrid) CanSend(email mmailer.Email) bool {
 func (m *Sendgrid) Send(_ context.Context, email mmailer.Email) (res []mmailer.Response, err error) {
 	from := mail.NewEmail(email.From.Name, email.From.Email)
 
-	message := mail.NewSingleEmail(from, email.Subject, nil, email.Text, email.Html)
+	// Force sendgrid to send HTML Body as UTF8 by appending a "word joiner" (U+2060)
+	// otherwise sendgrid encodes the HTML as iso-8859-1 if the HTML lacks any Unicode characters.
+	// which should be fine, but for some reason this causes gmail to clip the email.
+	message := mail.NewSingleEmail(from, email.Subject, nil, email.Text, email.Html+"\u2060")
 
 	services.ApplyConfig(m.Name(), email.ServiceConfig, m.confer, message)
 

--- a/services/sendgrid/sendgrid.go
+++ b/services/sendgrid/sendgrid.go
@@ -22,20 +22,24 @@ type Sendgrid struct {
 	confer  services.Configurer[*mail.SGMailV3]
 }
 
-func (m *Sendgrid) newClient(addr string) (*sendgrid.Client, error) {
+func (m *Sendgrid) newClient(addr string) (*sendgrid.Client, bool, error) {
 	k, ok := mmailer.KeyByEmailDomain(m.apiKeys, addr)
 	if !ok {
-		return nil, errors.New("sendgrid: no api key found for " + addr)
+		return nil, false, errors.New("sendgrid: no api key found for " + addr)
 	}
 	client := sendgrid.NewSendClient(k.Key)
 	if k.Props != nil && k.Props["region"] == "eu" {
 		var err error
 		client.Request, err = sendgrid.SetDataResidency(client.Request, "eu")
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
-	return client, nil
+	unicodeHack := false
+	if k.Props != nil && k.Props["unicode-hack"] == "true" {
+		unicodeHack = true
+	}
+	return client, unicodeHack, nil
 }
 
 func New(apiKeys []mmailer.ApiKey) *Sendgrid {
@@ -55,12 +59,21 @@ func (m *Sendgrid) CanSend(email mmailer.Email) bool {
 }
 
 func (m *Sendgrid) Send(_ context.Context, email mmailer.Email) (res []mmailer.Response, err error) {
-	from := mail.NewEmail(email.From.Name, email.From.Email)
+	client, unicodeHack, err := m.newClient(email.From.Email)
+	if err != nil {
+		return nil, err
+	}
+	html := email.Html
 
-	// Force sendgrid to send HTML Body as UTF8 by appending a "word joiner" (U+2060)
-	// otherwise sendgrid encodes the HTML as iso-8859-1 if the HTML lacks any Unicode characters.
-	// which should be fine, but for some reason this causes gmail to clip the email.
-	message := mail.NewSingleEmail(from, email.Subject, nil, email.Text, email.Html+"\u2060")
+	if unicodeHack {
+		// Force sendgrid to send HTML Body as UTF8 by appending a "word joiner" (U+2060)
+		// otherwise sendgrid encodes the HTML as iso-8859-1 if the HTML lacks any Unicode characters.
+		// which should be fine, but for some reason this causes gmail to clip the email.
+		html += "\u2060"
+	}
+
+	from := mail.NewEmail(email.From.Name, email.From.Email)
+	message := mail.NewSingleEmail(from, email.Subject, nil, email.Text, html)
 
 	services.ApplyConfig(m.Name(), email.ServiceConfig, m.confer, message)
 
@@ -99,10 +112,6 @@ func (m *Sendgrid) Send(_ context.Context, email mmailer.Email) (res []mmailer.R
 			Name:    a.Name,
 			Address: a.Email,
 		})
-	}
-	client, err := m.newClient(email.From.Email)
-	if err != nil {
-		return nil, err
 	}
 	response, err := client.Send(message)
 	if err != nil {


### PR DESCRIPTION
For some reason sendgrid will encode all content automatically into the "most compatible" encoding if the email doesn't contain any unicode characters, like this, note the `iso-8859-1`.

```
--51bfa5d5ea8e8fa49f5fee1a3b8d505c465b530140daf49dd1a9ddd75627
Content-Transfer-Encoding: quoted-printable
Content-Type: text/plain; charset=us-ascii
Mime-Version: 1.0

Test 4
--51bfa5d5ea8e8fa49f5fee1a3b8d505c465b530140daf49dd1a9ddd75627
Content-Transfer-Encoding: quoted-printable
Content-Type: text/html; charset=iso-8859-1
Mime-Version: 1.0

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"...
```

This unfortunately causes gmail to clip emails:
<img width="431" height="101" alt="Screenshot 2025-10-29 at 10 11 42" src="https://github.com/user-attachments/assets/1577bcf9-e112-4a7b-a312-8a37d9446bb4" />

If we put any unicode char into the html body the html is encoded as UTF-8 and the gmail issue is fixed...